### PR TITLE
Fix issue 43: subtitles with newlines

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -73,12 +73,12 @@ Specify input format. *FORMAT* can be:
 
   - `rev` [docs](https://www.rev.com/api/attachmentsgetcontent)
 
-`-t` *FORMAT*, `--to`*FORMAT*  
+`-t` *FORMAT*, `--to`*FORMAT* 
 Specify output format. *FORMAT* can be:
 
   - `textgrid` or `TextGrid` [docs]()
 
-  - `darla` or `DarlaTextGrid` [docs]() :::
+  - `darla` or `DarlaTextGrid` [docs]()
 
 `-o` *FILE*, `--output_path` *FILE*  
 Write output to *FILE*.

--- a/setup.py
+++ b/setup.py
@@ -15,37 +15,37 @@ URL ="https://github.com/patrickschu/textgrid-convert/"
 EMAIL ="patrickschultz@utexas.edu"
 AUTHOR = "Patrick Schultz, Lars Hinrichs"
 REQUIRES_PYTHON = '>=3.0.0'
-VERSION = '0.4.2'
+VERSION = '0.4.3a'
 
 # What packages are required for this module to be executed?
 # FIXME is this needed
-REQUIRED = [
-"astroid>=2.3.3",
-"attrs>=19.3.0",
-"et-xmlfile>=1.0.1",
-"importlib-metadata>=1.1.0",
-"isort>=4.3.21",
-"jdcal>=1.4.1",
-"lazy-object-proxy>=1.4.3",
-"mccabe>=0.6.1",
-"more-itertools>=8.0.0",
-"numpy>=1.16.4",
-"openpyxl>=2.6.2",
-"packaging>=19.2",
-"pandas>=0.24.2",
-"pluggy>=0.13.1",
-"py>=1.8.0",
-"pylint>=2.4.4",
-"pyparsing>=2.4.5",
-"pytest>=5.3.1",
-"python-dateutil>=2.8.0",
-"pytz>=2019.1",
-"six>=1.12.0",
-"typed-ast>=1.4.0",
-"virtualenv>=16.7.2",
-"wcwidth>=0.1.7",
-"wrapt>=1.11.2",
-"XlsxWriter>=1.1.8",
+REQUIRED = [ 
+ "astroid>=2.3.3",
+ "attrs>=19.3.0",
+ "et-xmlfile>=1.0.1",
+ "importlib-metadata>=1.1.0",
+ "isort>=4.3.21",
+ "jdcal>=1.4.1",
+ "lazy-object-proxy>=1.4.3",
+ "mccabe>=0.6.1",
+ "more-itertools>=8.0.0",
+ "numpy>=1.16.4",
+ "openpyxl>=2.6.2",
+ "packaging>=19.2",
+ "pandas>=0.24.2",
+ "pluggy>=0.13.1",
+ "py>=1.8.0",
+ "pylint>=2.4.4",
+ "pyparsing>=2.4.5",
+ "pytest>=5.3.1",
+ "python-dateutil>=2.8.0",
+ "pytz>=2019.1",
+ "six>=1.12.0",
+ "typed-ast>=1.4.0",
+ "virtualenv>=16.7.2",
+ "wcwidth>=0.1.7",
+ "wrapt>=1.11.2",
+ "XlsxWriter>=1.1.8",
 
 ]
 
@@ -63,11 +63,13 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
-try:
-    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-        long_description = '\n' + f.read()
-except FileNotFoundError:
-    long_description = DESCRIPTION
+#try:
+#    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+#        long_description = '\n' + f.read()
+#except FileNotFoundError:
+#    long_description = DESCRIPTION
+
+long_description = DESCRIPTION
 
 # Load the package's __version__.py module as a dictionary.
 about = {}

--- a/tests/resources/sample_files/srts/issue_43.srt
+++ b/tests/resources/sample_files/srts/issue_43.srt
@@ -1,0 +1,12 @@
+139
+00:07:06,467 --> 00:07:08,847
+After that, I studied Armenian Studies .
+
+140
+00:07:08,847 --> 00:07:12,957
+In university? 
+Hamazkayin had opened
+
+141
+00:07:12,957 --> 00:07:16,827
+their own Armenian Studies department.

--- a/tests/resources/sample_files/srts/issue_43_fulltext.srt
+++ b/tests/resources/sample_files/srts/issue_43_fulltext.srt
@@ -1,0 +1,3269 @@
+1
+00:00:04,395 --> 00:00:07,405
+Now, we can start talking about your
+
+2
+00:00:07,405 --> 00:00:10,805
+family's story during the genocide.
+
+3
+00:00:10,805 --> 00:00:14,805
+My ancestors, my grandpa and grandma
+
+4
+00:00:14,805 --> 00:00:21,665
+in 1915, my mom's side was from Marash
+
+5
+00:00:21,665 --> 00:00:25,735
+and my dad's side was from Boursa.
+
+6
+00:00:25,735 --> 00:00:29,435
+My mother and father were born and raised
+
+7
+00:00:29,435 --> 00:00:31,477
+in Aleppo.
+
+8
+00:00:31,477 --> 00:00:33,787
+Like them, I was born in the
+
+9
+00:00:33,787 --> 00:00:35,907
+same city.
+
+10
+00:00:35,907 --> 00:00:39,287
+I went to school in that city. My entire
+
+11
+00:00:39,287 --> 00:00:42,497
+childhood was spent there.
+
+12
+00:00:42,497 --> 00:00:45,495
+I went to school in Aleppo and had a good
+
+13
+00:00:45,495 --> 00:00:48,355
+environment. I have also been
+
+14
+00:00:48,355 --> 00:00:50,985
+an Armenian language teacher.
+
+15
+00:00:50,985 --> 00:00:54,782
+I have left all my friends in Aleppo
+
+16
+00:00:54,782 --> 00:00:56,982
+and came to Yerevan.
+
+17
+00:00:56,982 --> 00:01:00,795
+Do you know how your grandparents came
+
+18
+00:01:00,795 --> 00:01:03,633
+to Turkey and to Syria?
+
+19
+00:01:03,633 --> 00:01:06,683
+It is not really clear how my family
+
+20
+00:01:06,683 --> 00:01:08,052
+from Marash came...
+
+21
+00:01:08,052 --> 00:01:10,792
+In 1915, they must have joined the other
+
+22
+00:01:10,792 --> 00:01:13,462
+Armenians that fled the country and went
+
+23
+00:01:13,462 --> 00:01:15,627
+to an orphanage in Aleppo.
+
+24
+00:01:15,627 --> 00:01:19,607
+In that orphanage, they introduced them
+
+25
+00:01:19,607 --> 00:01:25,397
+to my grandmother and grandfather.
+
+26
+00:01:25,397 --> 00:01:27,776
+And then, they got married.
+
+27
+00:01:27,776 --> 00:01:29,947
+On my dad's side, the same
+
+28
+00:01:29,947 --> 00:01:32,597
+thing happened. They were also raised
+
+29
+00:01:32,597 --> 00:01:34,253
+in an orphanage.
+
+30
+00:01:34,253 --> 00:01:38,643
+My grandparents met one another there
+
+31
+00:01:38,643 --> 00:01:41,303
+and got married.
+
+32
+00:01:41,303 --> 00:01:47,423
+Do you know what they did for work?
+
+33
+00:01:47,423 --> 00:01:51,423
+I do not know where they used to work
+
+34
+00:01:51,423 --> 00:01:53,823
+during that time.
+
+35
+00:01:53,823 --> 00:01:58,953
+On my dad's side, they owned some land
+
+36
+00:01:58,953 --> 00:02:02,118
+and agricultural properties.
+
+37
+00:02:02,118 --> 00:02:04,977
+On my mom's side, it is a bit harder
+
+38
+00:02:04,977 --> 00:02:07,344
+to know. My family goes back many
+
+39
+00:02:07,344 --> 00:02:09,529
+generations and it's hard to know
+
+40
+00:02:09,529 --> 00:02:11,129
+where they worked.
+
+41
+00:02:11,129 --> 00:02:16,649
+My grandpa was a mechanic.
+
+42
+00:02:18,350 --> 00:02:20,440
+What else should I say?
+
+43
+00:02:22,494 --> 00:02:25,114
+Do you know how hard it was to start
+
+44
+00:02:25,114 --> 00:02:29,834
+their life again in Aleppo after the war?
+
+45
+00:02:29,834 --> 00:02:32,384
+What difficulties did they face?
+
+46
+00:02:32,384 --> 00:02:35,154
+Yes, they did go through tough times
+
+47
+00:02:35,154 --> 00:02:37,088
+during the war.
+
+48
+00:02:37,088 --> 00:02:39,953
+Firstly, they have lived in metal
+
+49
+00:02:39,953 --> 00:02:43,454
+shacks. They are called metal shacks
+
+50
+00:02:43,454 --> 00:02:47,444
+for Armenians. In Arabic, they say
+
+51
+00:02:47,444 --> 00:02:49,574
+berakatl Armen.
+
+52
+00:02:49,574 --> 00:02:52,434
+Secondly, the Armenians missed having
+
+53
+00:02:52,434 --> 00:02:55,074
+a home and moved into their own houses.
+
+54
+00:02:55,074 --> 00:02:58,077
+Life started to improve and as soon as we
+
+55
+00:02:58,077 --> 00:03:03,337
+came to Aleppo or Syria in general...
+
+56
+00:03:03,337 --> 00:03:05,827
+we had some Armenian churches.
+
+57
+00:03:05,827 --> 00:03:08,287
+Next to the churches, we had Armenian
+
+58
+00:03:08,287 --> 00:03:10,477
+schools. In the beginning, we have had
+
+59
+00:03:10,477 --> 00:03:12,777
+year-around schools. The population were
+
+60
+00:03:12,777 --> 00:03:14,657
+all Turkish speakers.
+
+61
+00:03:14,657 --> 00:03:17,728
+Since it was mandatory, they spoke Turkish
+
+62
+00:03:17,728 --> 00:03:19,328
+for 500 years.
+
+63
+00:03:19,328 --> 00:03:21,648
+When they came to Aleppo, due to the
+
+64
+00:03:21,648 --> 00:03:24,328
+Armenian schools they attended, the
+
+65
+00:03:24,328 --> 00:03:26,938
+people became more and more Armenian.
+
+66
+00:03:26,938 --> 00:03:28,573
+They started teaching Armenian.
+
+67
+00:03:28,573 --> 00:03:30,148
+From generation to generation,
+
+68
+00:03:30,148 --> 00:03:32,048
+we feel more Armenian since we speak
+
+69
+00:03:32,048 --> 00:03:34,198
+Armenian and have Armenian schools.
+
+70
+00:03:34,198 --> 00:03:36,555
+We also have Armenian
+
+71
+00:03:36,555 --> 00:03:39,078
+at the secondary level.
+
+72
+00:03:41,521 --> 00:03:44,851
+In Aleppo, what do you do to remember
+
+73
+00:03:44,851 --> 00:03:48,191
+the 1915 genocide and April 24th?
+
+74
+00:03:48,191 --> 00:03:51,376
+On the morning of April 24th, we go to
+
+75
+00:03:51,376 --> 00:03:54,876
+the cemetery and gather around the chapel
+
+76
+00:03:54,876 --> 00:03:57,806
+to remember those that we lost by praying
+
+77
+00:03:57,806 --> 00:03:59,776
+and by lighting candles.
+
+78
+00:03:59,776 --> 00:04:02,554
+During that time and on some days,
+
+79
+00:04:02,554 --> 00:04:06,254
+lectures took place in the Armenian
+
+80
+00:04:06,254 --> 00:04:09,094
+community centers.
+
+81
+00:04:10,768 --> 00:04:13,068
+From generation to generation,
+
+82
+00:04:13,068 --> 00:04:15,698
+we continue to remember and to not forget
+
+83
+00:04:15,698 --> 00:04:17,962
+that we have a problem with keeping
+
+84
+00:04:17,962 --> 00:04:20,112
+our Armenianhood. It is not only about
+
+85
+00:04:20,112 --> 00:04:22,292
+April 24th. It is not about tears.
+
+86
+00:04:22,292 --> 00:04:24,542
+Armenians do get sad and emotional
+
+87
+00:04:24,542 --> 00:04:27,542
+about what happened to our people.
+
+88
+00:04:27,542 --> 00:04:31,312
+We have been reborn and are
+
+89
+00:04:31,312 --> 00:04:35,892
+still living. We are still here. They said
+
+90
+00:04:35,892 --> 00:04:38,812
+that they are going to kill every
+
+91
+00:04:38,812 --> 00:04:42,412
+Armenian and leave one. They are going to
+
+92
+00:04:42,412 --> 00:04:45,462
+put that person in a museum. They did not
+
+93
+00:04:45,462 --> 00:04:49,212
+succeed in doing that. Because of that,
+
+94
+00:04:49,212 --> 00:04:52,402
+April 24th is a time of sorrow
+
+95
+00:04:52,402 --> 00:04:56,092
+for us. At the same time, it is
+
+96
+00:04:56,092 --> 00:04:58,882
+a victory for the Armenian people.
+
+97
+00:04:58,882 --> 00:05:01,842
+We are still present. We are still here.
+
+98
+00:05:01,842 --> 00:05:04,752
+We still have demands and want restitution
+
+99
+00:05:04,752 --> 00:05:06,702
+from them. We are not sleeping.
+
+100
+00:05:06,702 --> 00:05:07,872
+We are awake.
+
+101
+00:05:07,872 --> 00:05:10,382
+From generation to generation, we teach
+
+102
+00:05:10,382 --> 00:05:13,072
+them Armenian heritage and spirit with
+
+103
+00:05:13,072 --> 00:05:15,852
+the help of our cultural organizations.
+
+104
+00:05:15,852 --> 00:05:17,999
+With that, we prepare the next
+
+105
+00:05:17,999 --> 00:05:19,679
+generation of Armenians.
+
+106
+00:05:19,679 --> 00:05:20,762
+That is great.
+
+107
+00:05:20,762 --> 00:05:23,672
+Tell me a bit about your childhood.
+
+108
+00:05:23,672 --> 00:05:26,352
+My childhood... I was really happy.
+
+109
+00:05:26,352 --> 00:05:29,482
+Where were you raised? Aleppo! Aleppo!
+
+110
+00:05:29,482 --> 00:05:31,882
+I was born in Aleppo. In which neighborhood?
+
+111
+00:05:31,882 --> 00:05:35,052
+Sulaymaniyah! I was born in Aleppo
+
+112
+00:05:35,052 --> 00:05:37,538
+and grew up there in the same house.
+
+113
+00:05:37,538 --> 00:05:40,638
+My house is still luckily there.
+
+114
+00:05:41,948 --> 00:05:44,928
+I had a good childhood and was very happy.
+
+115
+00:05:44,928 --> 00:05:48,098
+I always had a good life... always.
+
+116
+00:05:48,098 --> 00:05:52,098
+Which school did you attend?
+
+117
+00:05:52,098 --> 00:05:56,568
+I went to Lazar Najarian. I attended that
+
+118
+00:05:56,568 --> 00:06:01,378
+school. I graduated in 1984. In terms of
+
+119
+00:06:01,378 --> 00:06:04,868
+the different community centers, I do not
+
+120
+00:06:04,868 --> 00:06:10,388
+want to make a distinction between them.
+
+121
+00:06:10,388 --> 00:06:14,038
+All of the community centers do their work
+
+122
+00:06:14,038 --> 00:06:16,898
+in their own way and follow different
+
+123
+00:06:16,898 --> 00:06:19,718
+principles. The goal that they all share
+
+124
+00:06:19,718 --> 00:06:21,368
+is Armenians keeping their
+
+125
+00:06:21,368 --> 00:06:23,698
+Armenianhood in the Diaspora.
+
+126
+00:06:23,698 --> 00:06:26,187
+We used to go to the theater with my
+
+127
+00:06:26,187 --> 00:06:29,517
+family. We did not have the choice to
+
+128
+00:06:29,517 --> 00:06:33,907
+go to one and not the other.
+
+129
+00:06:33,907 --> 00:06:37,087
+May it be a theater performance or
+
+130
+00:06:37,087 --> 00:06:41,667
+a literary evening, we have attended most
+
+131
+00:06:41,667 --> 00:06:45,567
+of them. I have been part of the scouting
+
+132
+00:06:45,567 --> 00:06:49,217
+ranks for a few years (for a short time).
+
+133
+00:06:49,217 --> 00:06:51,827
+It was one of the most beautiful years
+
+134
+00:06:51,827 --> 00:06:53,707
+of my life.
+
+135
+00:06:57,197 --> 00:07:00,877
+Until when did you go to school?
+
+136
+00:07:00,877 --> 00:07:03,287
+I graduated with the 1984 class.
+
+137
+00:07:03,287 --> 00:07:04,897
+High school
+
+138
+00:07:04,897 --> 00:07:06,467
+After you said...
+
+139
+00:07:06,467 --> 00:07:08,847
+After that, I studied Armenian Studies .
+
+140
+00:07:08,847 --> 00:07:12,957
+In university?
+-Hamazkayin had opened
+
+141
+00:07:12,957 --> 00:07:16,827
+their own Armenian Studies department.
+
+142
+00:07:16,827 --> 00:07:19,587
+A very long time ago, I went to
+
+143
+00:07:19,587 --> 00:07:22,157
+the British Council.
+
+144
+00:07:25,637 --> 00:07:28,187
+What kind of work did you do?
+
+145
+00:07:28,187 --> 00:07:31,127
+I have been an Armenian language teacher.
+
+146
+00:07:31,127 --> 00:07:34,467
+And... when you were an Armenian teacher,
+
+147
+00:07:34,467 --> 00:07:37,017
+did you think that it was
+
+148
+00:07:37,017 --> 00:07:40,197
+your responsibility to teach them
+
+149
+00:07:40,197 --> 00:07:43,787
+the language and about their culture?
+
+150
+00:07:43,787 --> 00:07:46,207
+Yes, it is important to know about
+
+151
+00:07:46,207 --> 00:07:49,117
+their culture. To teach Armenians the
+
+152
+00:07:49,117 --> 00:07:52,527
+Armenian language is a big responsibility
+
+153
+00:07:52,527 --> 00:07:54,397
+in the Diaspora.
+
+154
+00:07:54,397 --> 00:07:56,977
+Our teaching is not limited to learning
+
+155
+00:07:56,977 --> 00:07:59,717
+how to read and write and studying grammar
+
+156
+00:07:59,717 --> 00:08:02,457
+and literature. It is also to teach them
+
+157
+00:08:02,457 --> 00:08:04,917
+Armenian values by introducing
+
+158
+00:08:04,917 --> 00:08:08,117
+the students to Armenian symbols in order to
+
+159
+00:08:08,117 --> 00:08:11,027
+make them feel a sense of belonging
+
+160
+00:08:11,027 --> 00:08:13,337
+to the Armenian culture.
+
+161
+00:08:13,337 --> 00:08:15,337
+If someone asks them
+
+162
+00:08:15,337 --> 00:08:16,867
+about who they are
+
+163
+00:08:16,867 --> 00:08:18,447
+they would say Armenian.
+
+164
+00:08:18,447 --> 00:08:20,617
+"What does it mean to be an Armenian?"
+
+165
+00:08:20,617 --> 00:08:22,727
+They should be able to say that
+
+166
+00:08:22,727 --> 00:08:24,809
+Armenians are the group of people that
+
+167
+00:08:24,809 --> 00:08:27,083
+lived during the times of Dikran Medz
+
+168
+00:08:27,083 --> 00:08:29,798
+a long time ago. We have been a prominent
+
+169
+00:08:29,798 --> 00:08:33,158
+nation from sea to sea. We have had some
+
+170
+00:08:33,158 --> 00:08:36,250
+well-known Armenians like Viktor Ambartsumian
+
+171
+00:08:36,250 --> 00:08:38,250
+and Aram Khachaturian.
+
+172
+00:08:38,250 --> 00:08:40,950
+We have had many famous personalities.
+
+173
+00:08:40,950 --> 00:08:43,540
+It would be hard to count them all.
+
+174
+00:08:43,540 --> 00:08:46,000
+We should remember the individuals that
+
+175
+00:08:46,000 --> 00:08:48,350
+fought for our people and be proud of all
+
+176
+00:08:48,350 --> 00:08:50,860
+the things they have done for us.
+
+177
+00:08:50,860 --> 00:08:53,450
+We have to tell the new generation
+
+178
+00:08:53,450 --> 00:08:55,810
+about this. So, they hear and know
+
+179
+00:08:55,810 --> 00:08:58,790
+what is being an Armenian and feel
+
+180
+00:08:58,790 --> 00:09:01,640
+a sense of belongingness.
+
+181
+00:09:01,640 --> 00:09:05,700
+Only speaking Armenian is not enough.
+
+182
+00:09:05,700 --> 00:09:08,960
+And which school?
+
+183
+00:09:08,960 --> 00:09:11,355
+I was at Zvartnots Primary School.
+
+184
+00:09:11,355 --> 00:09:16,145
+And... do you think that the students
+
+185
+00:09:16,145 --> 00:09:20,200
+are interested in this subject matter?
+
+186
+00:09:20,200 --> 00:09:22,230
+The teacher is the person that should
+
+187
+00:09:22,230 --> 00:09:24,070
+make them interested in it.
+
+188
+00:09:24,070 --> 00:09:26,322
+They say that learning about literature
+
+189
+00:09:26,322 --> 00:09:28,692
+can be boring, but it is not like that.
+
+190
+00:09:28,692 --> 00:09:32,172
+The teacher can get them interested in our
+
+191
+00:09:32,172 --> 00:09:36,112
+culture, because our culture is very
+
+192
+00:09:36,112 --> 00:09:39,432
+beautiful. You can make it more
+
+193
+00:09:39,432 --> 00:09:42,062
+interesting for the students by making
+
+194
+00:09:42,062 --> 00:09:44,952
+them relate to the subject.
+
+195
+00:09:44,952 --> 00:09:48,032
+I did all the work. I do not know how much
+
+196
+00:09:48,032 --> 00:09:50,732
+I succeeded in that since I have only
+
+197
+00:09:50,732 --> 00:09:53,692
+worked for 10 years. Before that, I worked
+
+198
+00:09:53,692 --> 00:09:56,322
+with the English language...
+
+199
+00:09:56,322 --> 00:09:59,542
+not with Armenians.
+
+200
+00:09:59,542 --> 00:10:04,182
+When you were an Armenian teacher, did you
+
+201
+00:10:04,182 --> 00:10:07,852
+feel free in Syria to say anything in
+
+202
+00:10:07,852 --> 00:10:12,892
+school or about what the government allows
+
+203
+00:10:12,892 --> 00:10:15,832
+and what it does not?
+
+204
+00:10:15,832 --> 00:10:20,092
+We had permission for 4 hours per week
+
+205
+00:10:20,092 --> 00:10:24,412
+to teach the Armenian language
+
+206
+00:10:24,412 --> 00:10:28,052
+in Armenian schools and 2 hours
+
+207
+00:10:28,052 --> 00:10:30,132
+to teach religion.
+
+208
+00:10:30,132 --> 00:10:34,482
+We were free. We had Armenian language
+
+209
+00:10:34,482 --> 00:10:37,482
+and religion books.
+
+210
+00:10:37,482 --> 00:10:40,242
+We had no restrictions.
+
+211
+00:10:40,242 --> 00:10:41,952
+We have been very free.
+
+212
+00:10:41,952 --> 00:10:44,432
+We have also had our own printing press
+
+213
+00:10:44,432 --> 00:10:47,342
+and our newspapers and printed books
+
+214
+00:10:47,342 --> 00:10:50,072
+in Armenian. We would easily receive
+
+215
+00:10:50,072 --> 00:10:52,572
+permission to print from the Syrian
+
+216
+00:10:52,572 --> 00:10:55,102
+government. Until the time that we did not
+
+217
+00:10:55,102 --> 00:10:57,762
+make a mistake and say and/or write
+
+218
+00:10:57,762 --> 00:11:00,002
+something wrong about the government
+
+219
+00:11:00,002 --> 00:11:02,722
+or against religion, we could print
+
+220
+00:11:02,722 --> 00:11:05,782
+anything. It was a positive thing to be
+
+221
+00:11:05,782 --> 00:11:08,142
+an Armenian in Syria. As a minority,
+
+222
+00:11:08,142 --> 00:11:09,822
+we had many rights.
+
+223
+00:11:09,822 --> 00:11:13,632
+Everyone was equal. Everyone was equal.
+
+224
+00:11:13,632 --> 00:11:16,752
+The Arabs, the Armenians, the Assyrians,
+
+225
+00:11:16,752 --> 00:11:19,532
+and the Kurds, all had equal rights.
+
+226
+00:11:19,532 --> 00:11:24,282
+Unlike some other minorities, we had
+
+227
+00:11:24,282 --> 00:11:27,292
+schools, the printing press, theaters,
+
+228
+00:11:27,292 --> 00:11:31,862
+and scouting ranks. We had all the rights.
+
+229
+00:11:31,862 --> 00:11:34,512
+We were never treated differently
+
+230
+00:11:34,512 --> 00:11:38,222
+by the government... not by our last prime
+
+231
+00:11:38,222 --> 00:11:41,912
+minister and not by the current one.
+
+232
+00:11:41,912 --> 00:11:45,732
+Did you experience any difficulty?
+
+233
+00:11:45,732 --> 00:11:48,862
+I know you said that the government did
+
+234
+00:11:48,862 --> 00:11:51,942
+not cause any difficulty. Did the people?
+
+235
+00:11:51,942 --> 00:11:55,592
+The people? No, they were very respectful
+
+236
+00:11:55,592 --> 00:11:58,902
+in regards to us. The Arabs were very
+
+237
+00:11:58,902 --> 00:12:02,202
+respectful towards us. All of us have had
+
+238
+00:12:02,202 --> 00:12:04,942
+friendships. We all have had good
+
+239
+00:12:04,942 --> 00:12:07,712
+and honest friends. We have never been
+
+240
+00:12:07,712 --> 00:12:09,512
+told you are Armenian...
+
+241
+00:12:09,512 --> 00:12:11,362
+why do you live here?
+
+242
+00:12:11,362 --> 00:12:13,972
+You should go back to Armenia. They have
+
+243
+00:12:13,972 --> 00:12:16,132
+never said that. On the contrary,
+
+244
+00:12:16,132 --> 00:12:21,182
+they were happy with us. The Arab culture
+
+245
+00:12:21,182 --> 00:12:24,712
+has always shown respect to the Armenian people.
+
+246
+00:12:24,712 --> 00:12:28,332
+Do you see a difference between
+
+247
+00:12:28,332 --> 00:12:32,212
+Armenians and non-Armenians in terms
+
+248
+00:12:32,212 --> 00:12:34,662
+of how they were treated? A difference?
+
+249
+00:12:34,662 --> 00:12:39,112
+All Syrians are one. There could not be
+
+250
+00:12:39,112 --> 00:12:42,022
+any difference between them. As Syrians,
+
+251
+00:12:42,022 --> 00:12:45,602
+we were equal. We had not noticed any
+
+252
+00:12:45,602 --> 00:12:49,422
+difference. When there were religious
+
+253
+00:12:49,422 --> 00:12:54,142
+events, like Easter or other holidays,
+
+254
+00:12:54,142 --> 00:12:57,502
+we would celebrate them differently
+
+255
+00:12:57,502 --> 00:12:59,922
+than others since we were Christian.
+
+256
+00:12:59,922 --> 00:13:05,062
+In general! In general, we were one.
+
+257
+00:13:05,062 --> 00:13:06,812
+There was no difference
+
+258
+00:13:06,812 --> 00:13:08,422
+between us. On the contrary,
+
+259
+00:13:08,422 --> 00:13:11,022
+we would visit each other. They would
+
+260
+00:13:11,022 --> 00:13:13,302
+visit us during the holidays. We would
+
+261
+00:13:13,302 --> 00:13:16,052
+visit them and wish them happy holidays.
+
+262
+00:13:16,052 --> 00:13:19,572
+We have never felt any difference.
+
+263
+00:13:19,572 --> 00:13:22,712
+When you got older (apart from work),
+
+264
+00:13:22,712 --> 00:13:25,982
+what would you do in your life?
+
+265
+00:13:25,982 --> 00:13:31,695
+I had a strong social life. Strong social life!
+
+266
+00:13:31,695 --> 00:13:36,005
+I like having friends. I have gone to
+
+267
+00:13:36,005 --> 00:13:38,785
+a lot of places with my brother like
+
+268
+00:13:38,785 --> 00:13:41,965
+historical castles and other antiquities.
+
+269
+00:13:41,965 --> 00:13:44,155
+Syria is a rich country with its
+
+270
+00:13:44,155 --> 00:13:46,675
+historical sites. If you have heard of
+
+271
+00:13:46,675 --> 00:13:50,495
+the city of Palmyra, it is very known.
+
+272
+00:13:50,495 --> 00:13:53,645
+I visited a lot of ancient places in Syria with my brother.
+
+273
+00:13:53,645 --> 00:13:55,665
+Do you want
+
+274
+00:13:55,665 --> 00:13:58,285
+to explain anything from your life
+
+275
+00:13:58,285 --> 00:13:59,915
+before the war?
+
+276
+00:13:59,915 --> 00:14:02,135
+Before the war, I do not have anything
+
+277
+00:14:02,135 --> 00:14:04,145
+specific to talk about. I already said
+
+278
+00:14:04,145 --> 00:14:06,135
+everything. I talked about the type
+
+279
+00:14:06,135 --> 00:14:08,575
+of life we had... a good and happy life.
+
+280
+00:14:08,575 --> 00:14:11,125
+Difficulties! We cannot call it
+
+281
+00:14:11,125 --> 00:14:14,205
+difficulties. These are normal
+
+282
+00:14:14,205 --> 00:14:16,815
+difficulties that we have overcome
+
+283
+00:14:16,815 --> 00:14:21,185
+in life. Before the war, it was very good.
+
+284
+00:14:21,185 --> 00:14:23,715
+After the war, however, everything changed.
+
+285
+00:14:23,715 --> 00:14:28,745
+Before 2011, were there
+
+286
+00:14:28,745 --> 00:14:32,305
+any signs that a war was going to
+
+287
+00:14:32,305 --> 00:14:34,125
+start soon?
+
+288
+00:14:34,125 --> 00:14:38,555
+For the most part, there were signs.
+
+289
+00:14:38,555 --> 00:14:42,355
+Things happened. Some governments
+
+290
+00:14:42,355 --> 00:14:44,825
+threatened others.
+
+291
+00:14:44,825 --> 00:14:47,425
+Middle Eastern countries have
+
+292
+00:14:47,425 --> 00:14:50,715
+always been in danger. The worry about
+
+293
+00:14:50,715 --> 00:14:53,445
+a war starting has always been there.
+
+294
+00:14:53,445 --> 00:14:56,195
+But until the last minute, you cannot know
+
+295
+00:14:56,195 --> 00:14:58,405
+that for sure a war will take place.
+
+296
+00:14:58,405 --> 00:15:00,815
+Maybe, they will come to an agreement.
+
+297
+00:15:00,815 --> 00:15:03,315
+You will get convinced of that and will
+
+298
+00:15:03,315 --> 00:15:06,695
+always have hope that it will not happen.
+
+299
+00:15:06,695 --> 00:15:11,035
+When did you know the war in Syria
+
+300
+00:15:11,035 --> 00:15:15,905
+had started? What were the first signs?
+
+301
+00:15:15,905 --> 00:15:17,975
+In the beginning, it started at
+
+302
+00:15:17,975 --> 00:15:20,495
+the outskirts. We heard the sounds.
+
+303
+00:15:20,495 --> 00:15:24,615
+I visited Armenia for 2 months. I was
+
+304
+00:15:24,615 --> 00:15:28,145
+going to return to Aleppo. They came
+
+305
+00:15:28,145 --> 00:15:30,185
+and took over the city.
+
+306
+00:15:30,185 --> 00:15:32,765
+I stayed here for a while. A lot
+
+307
+00:15:32,765 --> 00:15:35,685
+of people came from Aleppo. They came
+
+308
+00:15:35,685 --> 00:15:41,155
+in 2012 in August and September. It was
+
+309
+00:15:41,155 --> 00:15:45,325
+during that time. I stayed here too. Then,
+
+310
+00:15:45,325 --> 00:15:48,315
+there were people that returned to Aleppo.
+
+311
+00:15:48,315 --> 00:15:50,475
+During New Year's Day, I returned too.
+
+312
+00:15:50,475 --> 00:15:53,735
+I stayed there for 6 months. Then, I went
+
+313
+00:15:53,735 --> 00:15:58,705
+back. In June 2013, I came back to
+
+314
+00:15:58,705 --> 00:16:01,685
+Armenia. I came back here.
+
+315
+00:16:01,685 --> 00:16:06,175
+When you traveled from Syria
+
+316
+00:16:06,175 --> 00:16:08,625
+to Armenia and from Armenia to Syria... how was it?
+
+317
+00:16:08,625 --> 00:16:11,085
+The first time, I came here on
+
+318
+00:16:11,085 --> 00:16:13,775
+an airplane and returned the same way.
+
+319
+00:16:13,775 --> 00:16:18,535
+The second time, I came with a car.
+
+320
+00:16:18,535 --> 00:16:21,055
+We came on our own. We passed
+
+321
+00:16:21,055 --> 00:16:23,935
+the Turkish border and went to Georgia
+
+322
+00:16:23,935 --> 00:16:25,425
+and after Armenia.
+
+323
+00:16:25,425 --> 00:16:26,425
+Any difficulties?
+
+324
+00:16:26,425 --> 00:16:28,775
+Of course, there were going to be some
+
+325
+00:16:28,775 --> 00:16:31,055
+difficulties. It was evident that we were
+
+326
+00:16:31,055 --> 00:16:32,765
+going to have some difficulties.
+
+327
+00:16:32,765 --> 00:16:35,065
+We left illegally. So, we were going
+
+328
+00:16:35,065 --> 00:16:37,145
+to face some difficulties.
+
+329
+00:16:37,145 --> 00:16:40,385
+The 6 months that you were in Syria...
+
+330
+00:16:40,385 --> 00:16:43,135
+Yes. What state was Aleppo in?
+
+331
+00:16:43,135 --> 00:16:45,085
+It was really bad. It was really bad.
+
+332
+00:16:45,085 --> 00:16:46,895
+There was no electricity.
+
+333
+00:16:46,895 --> 00:16:48,650
+There was no water.
+
+334
+00:16:48,650 --> 00:16:49,505
+Excuse me.
+
+335
+00:16:49,505 --> 00:16:51,825
+Yes, there was in the beginning.
+
+336
+00:16:51,825 --> 00:16:52,985
+After...
+
+337
+00:16:52,985 --> 00:16:56,975
+Always, there was the fear of death.
+
+338
+00:16:56,975 --> 00:17:00,155
+It was not the fear of death per se, but
+
+339
+00:17:00,155 --> 00:17:02,675
+the way that someone was going to die.
+
+340
+00:17:02,675 --> 00:17:04,645
+It was the violent depictions displayed
+
+341
+00:17:04,645 --> 00:17:08,115
+in videos and photos on YouTube.
+
+342
+00:17:08,115 --> 00:17:10,525
+More than death, you would worry about
+
+343
+00:17:10,525 --> 00:17:12,565
+the way you were going to die.
+
+344
+00:17:12,565 --> 00:17:14,615
+You always heard the people
+
+345
+00:17:14,615 --> 00:17:16,255
+and the sound of bombs.
+
+346
+00:17:16,255 --> 00:17:18,175
+At night, it would get worse.
+
+347
+00:17:18,175 --> 00:17:20,855
+In the morning, it would be less.
+
+348
+00:17:20,855 --> 00:17:23,915
+And why? I turned back,
+
+349
+00:17:23,915 --> 00:17:26,315
+because it was safer.
+
+350
+00:17:26,315 --> 00:17:28,895
+I came back to Armenia, because it was safer.
+
+351
+00:17:28,895 --> 00:17:32,415
+Why did you go back
+
+352
+00:17:32,415 --> 00:17:35,115
+to Armenia and then Syria?
+
+353
+00:17:35,115 --> 00:17:40,515
+I went to Syria. My brother was in Syria.
+
+354
+00:17:40,515 --> 00:17:45,315
+We were going to celebrate New Year's.
+
+355
+00:17:45,315 --> 00:17:48,625
+We had no one there. We did not want
+
+356
+00:17:48,625 --> 00:17:50,335
+my brother to be alone.
+
+357
+00:17:50,335 --> 00:17:52,615
+I am here. He is there.
+
+358
+00:17:52,615 --> 00:17:55,395
+I took the risk. I did not want to...
+
+359
+00:17:55,395 --> 00:17:57,295
+In this world, he only has me
+
+360
+00:17:57,295 --> 00:17:59,485
+and I only have him.
+
+361
+00:17:59,485 --> 00:18:01,615
+That is how I went there.
+
+362
+00:18:01,615 --> 00:18:04,445
+And then, we came here together.
+
+363
+00:18:04,445 --> 00:18:09,115
+And... are the other families still in Aleppo?
+
+364
+00:18:09,115 --> 00:18:12,835
+I do not have a mom and a dad.
+
+365
+00:18:12,835 --> 00:18:16,025
+Other family members? My mom and my dad
+
+366
+00:18:16,025 --> 00:18:19,435
+have already passed away. My brother...
+
+367
+00:18:19,435 --> 00:18:22,665
+Before the war?
+
+368
+00:18:22,665 --> 00:18:26,555
+My mom died before the war due to an illness.
+
+369
+00:18:26,555 --> 00:18:30,785
+My dad died long before that.
+
+370
+00:18:32,075 --> 00:18:38,345
+And... the first time you went to Armenia?
+
+371
+00:18:38,345 --> 00:18:41,595
+Was that the first time that you went to Armenia?
+
+372
+00:18:41,595 --> 00:18:45,135
+I came here in 2004 with other
+
+373
+00:18:45,135 --> 00:18:47,735
+teachers for training purposes
+
+374
+00:18:47,735 --> 00:18:50,675
+for 1 month. I was in love with Armenia.
+
+375
+00:18:50,675 --> 00:18:54,175
+I had left my soul here. I wanted to
+
+376
+00:18:54,175 --> 00:18:58,175
+live in Armenia. We had decided with
+
+377
+00:18:58,175 --> 00:19:02,175
+the family to live here. My brother would
+
+378
+00:19:02,175 --> 00:19:06,175
+come when he had breaks.
+
+379
+00:19:06,175 --> 00:19:09,845
+He would say that we should live here
+
+380
+00:19:09,845 --> 00:19:12,135
+and go back later. We said that it is
+
+381
+00:19:12,135 --> 00:19:14,545
+hard. We already have good jobs
+
+382
+00:19:14,545 --> 00:19:16,085
+back home.
+
+383
+00:19:16,085 --> 00:19:18,325
+And yes, we came.
+
+384
+00:19:18,325 --> 00:19:23,015
+Did you come in 2012?
+
+385
+00:19:23,015 --> 00:19:25,515
+The last time was in 2013.
+
+386
+00:19:25,515 --> 00:19:28,435
+But the first time in 2012? Yes, 2012.
+
+387
+00:19:28,435 --> 00:19:30,735
+The first first time was in 2004. 2004!
+
+388
+00:19:30,735 --> 00:19:32,965
+The second one was in 2012.
+
+389
+00:19:32,965 --> 00:19:36,905
+How was your new life? How did you feel
+
+390
+00:19:36,905 --> 00:19:39,205
+in Armenia? How was life there?
+
+391
+00:19:39,205 --> 00:19:41,055
+What were the difficulties?
+
+392
+00:19:41,055 --> 00:19:44,145
+2012? Yes! You mean the differences
+
+393
+00:19:44,145 --> 00:19:45,575
+in 2004, right?
+
+394
+00:19:45,575 --> 00:19:48,495
+No, no, Not the differences.
+
+395
+00:19:48,495 --> 00:19:52,005
+You said that you went in 2012 just
+
+396
+00:19:52,005 --> 00:19:54,615
+to visit and you ended up staying
+
+397
+00:19:54,615 --> 00:19:57,255
+here after. How was it during that time?
+
+398
+00:19:57,255 --> 00:20:00,755
+Living here is different. Visiting is
+
+399
+00:20:00,755 --> 00:20:02,985
+different too.
+
+400
+00:20:02,985 --> 00:20:05,755
+Living here is very difficult. You really
+
+401
+00:20:05,755 --> 00:20:08,605
+have to have a good job to live here.
+
+402
+00:20:08,605 --> 00:20:13,575
+And... when you decided that I visited
+
+403
+00:20:13,575 --> 00:20:16,575
+and now I want to live here, did anyone
+
+404
+00:20:16,575 --> 00:20:18,965
+help you with where to live?
+
+405
+00:20:18,965 --> 00:20:20,915
+Or how to find a job?
+
+406
+00:20:20,915 --> 00:20:27,015
+No! How to help? I stayed in Echmiadzin.
+
+407
+00:20:27,015 --> 00:20:30,675
+The people were really great. I have had
+
+408
+00:20:30,675 --> 00:20:34,535
+neighbours... as soon as I moved to
+
+409
+00:20:34,535 --> 00:20:37,175
+a house, they always came to ask
+
+410
+00:20:37,175 --> 00:20:38,725
+if I needed anything.
+
+411
+00:20:38,725 --> 00:20:42,215
+If I said, yes, I need something.
+
+412
+00:20:42,215 --> 00:20:44,885
+They have offered pots, pans, blankets,
+
+413
+00:20:44,885 --> 00:20:46,355
+pillows, and clothing.
+
+414
+00:20:46,355 --> 00:20:48,355
+If I said, yes, I need something.
+
+415
+00:20:48,355 --> 00:20:50,715
+I would most probably have rooms
+
+416
+00:20:50,715 --> 00:20:52,475
+full of pots and pans and blankets.
+
+417
+00:20:52,475 --> 00:20:55,705
+The community always offered to help.
+
+418
+00:20:55,705 --> 00:20:58,965
+We were always treated well.
+
+419
+00:20:58,965 --> 00:21:01,475
+[Children yelling in background] 
+Children? Yes!
+
+420
+00:21:01,475 --> 00:21:05,375
+I have received help from Mission
+
+421
+00:21:05,375 --> 00:21:08,565
+Armenia, and they helped pay my rent.
+
+422
+00:21:08,565 --> 00:21:11,445
+I have also received books
+
+423
+00:21:11,445 --> 00:21:14,795
+from the Red Cross (and that is
+
+424
+00:21:14,795 --> 00:21:17,805
+worth mentioning as well).
+
+425
+00:21:17,805 --> 00:21:21,355
+There is another organization
+
+426
+00:21:21,355 --> 00:21:25,385
+called UN in English.
+
+427
+00:21:25,385 --> 00:21:29,065
+They are always willing and continue to
+
+428
+00:21:29,065 --> 00:21:32,525
+help us. We also have Syrian centers
+
+429
+00:21:32,525 --> 00:21:35,733
+called ACMA. They distribute
+
+430
+00:21:35,733 --> 00:21:38,923
+nutrients/food every 3-4 months.
+
+431
+00:21:38,923 --> 00:21:41,993
+One of the charities helps us find
+
+432
+00:21:41,993 --> 00:21:45,663
+doctors. We get help from Syrian doctors,
+
+433
+00:21:45,663 --> 00:21:49,713
+and they take care of us without pay.
+
+434
+00:21:49,713 --> 00:21:52,903
+The government has made education free.
+
+435
+00:21:52,903 --> 00:21:55,973
+Going to the polyclinic is also free.
+
+436
+00:21:55,973 --> 00:21:58,153
+The government tries to help us
+
+437
+00:21:58,153 --> 00:22:00,233
+as much as possible.
+
+438
+00:22:00,233 --> 00:22:04,233
+And... the first time in Armenia...
+
+439
+00:22:04,233 --> 00:22:06,953
+not the first time but the second time...
+
+440
+00:22:06,953 --> 00:22:09,933
+did you work during that time? Where?
+
+441
+00:22:09,933 --> 00:22:13,893
+Here! Here, I taught people at home.
+
+442
+00:22:13,893 --> 00:22:17,213
+Taught! That is how they say it in Eastern
+
+443
+00:22:17,213 --> 00:22:20,223
+Armenian. So, I did one-on-one
+
+444
+00:22:20,223 --> 00:22:22,373
+sessions with kids.
+
+445
+00:22:22,373 --> 00:22:25,533
+In that way, I was able to make a living.
+
+446
+00:22:25,533 --> 00:22:27,923
+Second? The third time?
+
+447
+00:22:27,923 --> 00:22:30,983
+No! When I came here the last time,
+
+448
+00:22:30,983 --> 00:22:33,333
+I did one-on-one sessions. When I
+
+449
+00:22:33,333 --> 00:22:35,453
+came here to visit, no,
+
+450
+00:22:35,453 --> 00:22:38,283
+I just came to visit.
+
+451
+00:22:38,283 --> 00:22:45,493
+In 2014, the third time that you came,
+
+452
+00:22:45,493 --> 00:22:51,773
+where did you live? Or now, where do you live?
+
+453
+00:22:51,773 --> 00:22:54,273
+I lived mostly in Etchmiadzin
+
+454
+00:22:54,273 --> 00:22:56,483
+and then came to Yerevan. They paid
+
+455
+00:22:56,483 --> 00:22:59,593
+the rent. When they stopped, I could
+
+456
+00:22:59,593 --> 00:23:02,373
+no longer continue to pay the rent.
+
+457
+00:23:02,373 --> 00:23:06,483
+It is hard to survive in Yerevan. I went
+
+458
+00:23:06,483 --> 00:23:09,833
+back to Etchmiadzin. And there,
+
+459
+00:23:09,833 --> 00:23:12,413
+Mission Armenia helped me
+
+460
+00:23:12,413 --> 00:23:14,933
+again. UN paid my rent.
+
+461
+00:23:14,933 --> 00:23:19,063
+After that, my dream was to live
+
+462
+00:23:19,063 --> 00:23:21,733
+in Yerevan. There are more job
+
+463
+00:23:21,733 --> 00:23:23,963
+opportunities in Yerevan.
+
+464
+00:23:23,963 --> 00:23:28,509
+I applied to UN and Mission Armenia,
+
+465
+00:23:28,509 --> 00:23:31,423
+and they helped me find a boarding room.
+
+466
+00:23:31,423 --> 00:23:33,853
+I have been living there for a year and a half now.
+
+467
+00:23:33,853 --> 00:23:39,243
+And... do you live here
+
+468
+00:23:39,243 --> 00:23:43,533
+and work with Mission Armenia?
+
+469
+00:23:43,533 --> 00:23:50,473
+I take part in trainings. I teach kids.
+
+470
+00:23:53,013 --> 00:23:55,873
+I give English classes
+
+471
+00:23:55,873 --> 00:23:58,703
+and sometimes Armenian.
+
+472
+00:23:58,703 --> 00:24:01,993
+Because... learning from Western to
+
+473
+00:24:01,993 --> 00:24:05,433
+Eastern Armenian is very easy. It is
+
+474
+00:24:05,433 --> 00:24:09,113
+much easier. The grammar and spelling
+
+475
+00:24:09,113 --> 00:24:12,203
+and etcetera are much easier.
+
+476
+00:24:12,203 --> 00:24:15,801
+And... how is life at the new house?
+
+477
+00:24:15,801 --> 00:24:20,752
+How is life there? I live in a unit
+
+478
+00:24:20,752 --> 00:24:24,383
+that has 5 boarding rooms.
+
+479
+00:24:24,383 --> 00:24:29,014
+We all live in the same unit.
+
+480
+00:24:29,014 --> 00:24:31,557
+The only problem is during winter
+
+481
+00:24:31,557 --> 00:24:34,113
+we had heating problems.
+
+482
+00:24:34,113 --> 00:24:38,933
+Last year! Last year, we did not have
+
+483
+00:24:38,933 --> 00:24:41,973
+a bathroom to take a shower in
+
+484
+00:24:41,973 --> 00:24:44,433
+or could not even do laundry. We were
+
+485
+00:24:44,433 --> 00:24:47,143
+not living in good conditions. As soon as
+
+486
+00:24:47,143 --> 00:24:50,053
+a drop of water would drip on the floor...
+
+487
+00:24:50,053 --> 00:24:53,908
+it was scary even the elderly could
+
+488
+00:24:53,908 --> 00:24:58,413
+have slipped. UN paid for the rent
+
+489
+00:24:58,413 --> 00:25:02,243
+and renovations of this housing unit.
+
+490
+00:25:02,243 --> 00:25:05,593
+Some renovations were done, but some have
+
+491
+00:25:05,593 --> 00:25:11,523
+not been completed and I do not know why.
+
+492
+00:25:11,523 --> 00:25:14,323
+Heating is an important issue
+
+493
+00:25:14,323 --> 00:25:15,323
+in the winter.
+
+494
+00:25:15,323 --> 00:25:19,033
+We really need it, but who is going to
+
+495
+00:25:19,033 --> 00:25:22,083
+help us and how I do not know.
+
+496
+00:25:22,083 --> 00:25:24,263
+How do you think the government
+
+497
+00:25:24,263 --> 00:25:26,703
+and the other organizations are going
+
+498
+00:25:26,703 --> 00:25:28,933
+to help Syrian-Armenians to have
+
+499
+00:25:28,933 --> 00:25:31,403
+a better and easier life here?
+
+500
+00:25:31,403 --> 00:25:36,813
+The government does all that it can.
+
+501
+00:25:36,813 --> 00:25:43,563
+They can only help within their limits.
+
+502
+00:25:43,563 --> 00:25:46,903
+The organizations and benefactors of other
+
+503
+00:25:46,903 --> 00:25:50,423
+foreign countries can help us more
+
+504
+00:25:50,423 --> 00:25:53,152
+effectively if it is well-coordinated
+
+505
+00:25:53,152 --> 00:25:54,663
+with local authorities.
+
+506
+00:25:54,663 --> 00:25:58,163
+Which organization and in what way...
+
+507
+00:25:58,163 --> 00:26:00,783
+that only they know.
+
+508
+00:26:00,783 --> 00:26:04,783
+I think that the organizations can help us
+
+509
+00:26:04,783 --> 00:26:08,513
+more, but they have already helped us
+
+510
+00:26:08,513 --> 00:26:10,543
+(like UN and the Red Cross).
+
+511
+00:26:10,543 --> 00:26:13,573
+They have already done that.
+
+512
+00:26:15,363 --> 00:26:20,003
+And... did you feel welcomed by
+
+513
+00:26:20,003 --> 00:26:23,433
+the Armenians living in Armenia?
+
+514
+00:26:23,433 --> 00:26:26,213
+Did you feel welcome and see any
+
+515
+00:26:26,213 --> 00:26:29,293
+differences in the culture?
+
+516
+00:26:29,293 --> 00:26:33,933
+On the contrary, I was emotionally ready
+
+517
+00:26:33,933 --> 00:26:37,603
+to live here from way before.
+
+518
+00:26:37,603 --> 00:26:40,383
+The Armenia population is not that
+
+519
+00:26:40,383 --> 00:26:42,933
+different compared to Syrian-Armenians.
+
+520
+00:26:42,933 --> 00:26:46,413
+They have been to and visited Aleppo
+
+521
+00:26:46,413 --> 00:26:49,463
+already. We are not foreigners. For us,
+
+522
+00:26:49,463 --> 00:26:53,643
+the Armenian culture is not different.
+
+523
+00:26:53,643 --> 00:26:56,193
+There can be some small differences.
+
+524
+00:26:56,193 --> 00:26:58,823
+The country the Diasporan
+
+525
+00:26:58,823 --> 00:27:01,793
+is from can have an effect on him/her.
+
+526
+00:27:01,793 --> 00:27:05,173
+Here, it is a purely Armenian culture.
+
+527
+00:27:05,173 --> 00:27:09,293
+Everything is very beautiful and nice.
+
+528
+00:27:09,293 --> 00:27:12,383
+There is not that much difference. I got
+
+529
+00:27:12,383 --> 00:27:16,603
+used to it quickly. I accepted them in
+
+530
+00:27:16,603 --> 00:27:21,113
+every way from their cuisine to their way
+
+531
+00:27:21,113 --> 00:27:25,223
+of thinking. It was not that difficult.
+
+532
+00:27:25,223 --> 00:27:28,123
+With those little cultural and language
+
+533
+00:27:28,123 --> 00:27:30,443
+differences, how do you keep your
+
+534
+00:27:30,443 --> 00:27:33,983
+Syrian-Armenian culture here in Armenia?
+
+535
+00:27:33,983 --> 00:27:36,983
+For the Syrian culture, first is
+
+536
+00:27:36,983 --> 00:27:39,983
+Western Armenian. I do not want to forget
+
+537
+00:27:39,983 --> 00:27:43,053
+Western Armenian. I want to pronounce
+
+538
+00:27:43,053 --> 00:27:45,663
+Eastern Armenian well, but I cannot.
+
+539
+00:27:45,663 --> 00:27:47,623
+I can talk (said in Western).
+
+540
+00:27:47,623 --> 00:27:49,833
+I can talk (said in Eastern).
+
+541
+00:27:49,833 --> 00:27:51,913
+Pronouncing it is difficult.
+
+542
+00:27:51,913 --> 00:27:53,773
+Unfortunately, we have lost
+
+543
+00:27:53,773 --> 00:27:55,893
+the traditional pronunciations.
+
+544
+00:27:55,893 --> 00:28:03,843
+As a Syrian culture, an Armenian
+
+545
+00:28:03,843 --> 00:28:08,003
+culture, a Syrian-Armenian culture,
+
+546
+00:28:08,003 --> 00:28:11,143
+we still have the same traditions and
+
+547
+00:28:11,143 --> 00:28:14,943
+continue to do things in the same way.
+
+548
+00:28:14,943 --> 00:28:18,723
+Do you still think that you live
+
+549
+00:28:18,723 --> 00:28:23,033
+in your homeland? This is not the same
+
+550
+00:28:23,033 --> 00:28:25,933
+homeland that your grandfathers
+
+551
+00:28:25,933 --> 00:28:29,003
+and grandmothers lived in? Do you still
+
+552
+00:28:29,003 --> 00:28:31,173
+feel that this is your homeland?
+
+553
+00:28:31,173 --> 00:28:33,713
+Of course, it is not the same. 100 years
+
+554
+00:28:33,713 --> 00:28:36,443
+ago, it was different. It is not about
+
+555
+00:28:36,443 --> 00:28:38,813
+the 100 years. Already 5 years ago,
+
+556
+00:28:38,813 --> 00:28:41,488
+Armenia was different. Life is more
+
+557
+00:28:41,488 --> 00:28:45,813
+difficult now. When I came as a tourist
+
+558
+00:28:45,813 --> 00:28:49,933
+just to visit, my point of view
+
+559
+00:28:49,933 --> 00:28:52,353
+was different. Now that I live here,
+
+560
+00:28:52,353 --> 00:28:55,243
+it is more difficult. I saw more
+
+561
+00:28:55,243 --> 00:28:58,463
+of the difficulties. It is mine
+
+562
+00:28:58,463 --> 00:29:01,283
+and I belong to it. The sense of
+
+563
+00:29:01,283 --> 00:29:05,043
+belongingness is very nice. All Armenians
+
+564
+00:29:05,043 --> 00:29:08,533
+have to put their roots in Armenia.
+
+565
+00:29:08,533 --> 00:29:11,493
+Every person has to put their roots in
+
+566
+00:29:11,493 --> 00:29:12,793
+their own land.
+
+567
+00:29:12,793 --> 00:29:16,073
+When on someone else's land you plant
+
+568
+00:29:16,073 --> 00:29:19,173
+a tree, you might not have the time to sit
+
+569
+00:29:19,173 --> 00:29:22,493
+under the tree's shadow. You have to plant
+
+570
+00:29:22,493 --> 00:29:24,973
+the tree on your own land.
+
+571
+00:29:24,973 --> 00:29:28,403
+Do you want to stay here? Or go back
+
+572
+00:29:28,403 --> 00:29:31,813
+to Aleppo? Or go somewhere else?
+
+573
+00:29:31,813 --> 00:29:35,743
+I want to go back to Aleppo, because
+
+574
+00:29:35,743 --> 00:29:38,713
+I miss the land that I grew up in
+
+575
+00:29:38,713 --> 00:29:41,983
+(my birthplace, my home, and my neighborhood).
+
+576
+00:29:41,983 --> 00:29:45,893
+I have lived there for 46 years before
+
+577
+00:29:45,893 --> 00:29:49,053
+coming here. Of course, I have a lot of
+
+578
+00:29:49,053 --> 00:29:53,633
+memories there and I miss everyone there,
+
+579
+00:29:53,633 --> 00:29:57,293
+but I want to continue to live in Armenia.
+
+580
+00:29:57,293 --> 00:30:01,713
+And... what do you want to do for work?
+
+581
+00:30:01,713 --> 00:30:06,333
+On my own? On my own! If I do not find
+
+582
+00:30:06,333 --> 00:30:10,603
+a good job, there is no hope.
+
+583
+00:30:10,603 --> 00:30:14,603
+There has to be a job out there.
+
+584
+00:30:14,603 --> 00:30:18,603
+You should not lose all hope.
+
+585
+00:30:18,603 --> 00:30:22,463
+To enjoy life, you have to create your own
+
+586
+00:30:22,463 --> 00:30:27,143
+aspirations. Without work, you cannot
+
+587
+00:30:27,143 --> 00:30:29,433
+do anything.
+
+588
+00:30:29,433 --> 00:30:31,633
+What kind of job do you want?
+
+589
+00:30:31,633 --> 00:30:34,423
+Whatever is available. This is Armenia.
+
+590
+00:30:34,423 --> 00:30:36,693
+You have to work with whatever work
+
+591
+00:30:36,693 --> 00:30:38,233
+is available.
+
+592
+00:30:38,233 --> 00:30:40,773
+You said that you do not have family in Aleppo.
+
+593
+00:30:40,773 --> 00:30:43,323
+No, I do not have family there.
+
+594
+00:30:43,323 --> 00:30:45,383
+Do you have any family there?
+
+595
+00:30:45,383 --> 00:30:46,853
+No, no family.
+
+596
+00:30:46,853 --> 00:30:49,643
+Yes, I have friends and neighbours there.
+
+597
+00:30:49,643 --> 00:30:51,933
+Are they still there?
+
+598
+00:30:51,933 --> 00:30:54,323
+For the most part, they went to Europe.
+
+599
+00:30:54,323 --> 00:30:57,423
+For the most part, no one is there now.
+
+600
+00:30:57,423 --> 00:31:00,443
+Is your house still there? Yes, it is.
+
+601
+00:31:00,443 --> 00:31:04,173
+Is anyone checking up on it? Yes!
+
+602
+00:31:09,412 --> 00:31:13,562
+In 1915, we had to... no... we were forced
+
+603
+00:31:13,562 --> 00:31:16,722
+to leave. We did not decide to leave.
+
+604
+00:31:16,722 --> 00:31:20,292
+Unfortunately, our forefathers were
+
+605
+00:31:20,292 --> 00:31:23,452
+all displaced in 1915.
+
+606
+00:31:23,452 --> 00:31:27,092
+From the war, the ruins, and the death
+
+607
+00:31:27,092 --> 00:31:29,932
+of many people, only a few of the families
+
+608
+00:31:29,932 --> 00:31:32,592
+made it to Syrian land.
+
+609
+00:31:32,592 --> 00:31:36,592
+Now, it is very different. No one told us
+
+610
+00:31:36,592 --> 00:31:41,222
+to leave Syria. Never. We left. There are
+
+611
+00:31:41,222 --> 00:31:44,592
+still a lot of Armenians that live in
+
+612
+00:31:44,592 --> 00:31:48,592
+Aleppo, Syria. We left. We had the ability
+
+613
+00:31:48,592 --> 00:31:51,992
+to leave. We had the convenience to
+
+614
+00:31:51,992 --> 00:31:55,012
+leave. We wanted to leave. From the people
+
+615
+00:31:55,012 --> 00:31:58,002
+that came to Armenia with us, they came
+
+616
+00:31:58,002 --> 00:32:00,992
+here temporarily. We thought the war
+
+617
+00:32:00,992 --> 00:32:03,452
+would end and we would go back.
+
+618
+00:32:03,452 --> 00:32:05,892
+That is the reason why we came here.
+
+619
+00:32:05,892 --> 00:32:08,122
+Now, I do not want to talk for other
+
+620
+00:32:08,122 --> 00:32:11,142
+people. For the most part, the people
+
+621
+00:32:11,142 --> 00:32:14,952
+that have work here do not go back.
+
+622
+00:32:14,952 --> 00:32:18,842
+When they have learned and gotten used to
+
+623
+00:32:18,842 --> 00:32:21,682
+the life here and have a job here,
+
+624
+00:32:21,682 --> 00:32:24,122
+I do not think that they will go back.
+
+625
+00:32:24,122 --> 00:32:26,662
+I highly doubt that Aleppo will go back
+
+626
+00:32:26,662 --> 00:32:29,072
+to the way it was. It will take a long
+
+627
+00:32:29,072 --> 00:32:31,512
+time for it to be the same as before.
+
+628
+00:32:31,512 --> 00:32:35,452
+It will take a long time.
+
+629
+00:32:35,452 --> 00:32:42,048
+And... for you, personally, what draws you to Armenia?
+
+630
+00:32:42,048 --> 00:32:45,662
+Personally! Since childhood, the love
+
+631
+00:32:45,662 --> 00:32:49,812
+for Armenia was in our house, at school,
+
+632
+00:32:49,812 --> 00:32:53,212
+and in the community centers. There is
+
+633
+00:32:53,212 --> 00:32:56,072
+a problem of keeping our Armenianhood.
+
+634
+00:32:56,072 --> 00:32:58,282
+The community centers and the schools
+
+635
+00:32:58,282 --> 00:33:02,092
+work with this issue. In our house,
+
+636
+00:33:02,092 --> 00:33:08,702
+patriotism was important. They always
+
+637
+00:33:08,702 --> 00:33:11,322
+mentioned Armenia. When I came
+
+638
+00:33:11,322 --> 00:33:16,062
+to Armenia in 2004 for 1 month,
+
+639
+00:33:16,062 --> 00:33:19,302
+I left my soul here.
+
+640
+00:33:19,302 --> 00:33:23,552
+I wanted to live here, but we could not
+
+641
+00:33:23,552 --> 00:33:27,552
+dare to do that because of work. We could
+
+642
+00:33:27,552 --> 00:33:32,052
+not destroy everything there and start
+
+643
+00:33:32,052 --> 00:33:34,442
+a new life here. We did not know if
+
+644
+00:33:34,442 --> 00:33:37,072
+we would succeed or not. I already
+
+645
+00:33:37,072 --> 00:33:40,082
+wanted to live in Armenia. And now,
+
+646
+00:33:40,082 --> 00:33:42,782
+I am here.
+
+647
+00:33:42,782 --> 00:33:44,212
+Very good!
+
+648
+00:33:44,212 --> 00:33:50,172
+What advice would you give? To give advice
+
+649
+00:33:50,172 --> 00:33:53,542
+to who? To Syrian-Armenians?
+
+650
+00:33:53,542 --> 00:33:56,562
+Yes, the ones that returned to Armenia.
+
+651
+00:33:56,562 --> 00:33:59,042
+I do not give myself permission to give
+
+652
+00:33:59,042 --> 00:34:02,782
+advice to others, because every
+
+653
+00:34:02,782 --> 00:34:08,992
+difficulty and experience in life teaches
+
+654
+00:34:08,992 --> 00:34:12,042
+you something new. You will see that
+
+655
+00:34:12,042 --> 00:34:14,782
+there is still a lot that you do not know.
+
+656
+00:34:14,782 --> 00:34:16,952
+For this reason, I cannot give advice
+
+657
+00:34:16,952 --> 00:34:19,592
+to anybody. Everyone will know what is
+
+658
+00:34:19,592 --> 00:34:22,482
+convenient for them and will think before
+
+659
+00:34:22,482 --> 00:34:26,632
+taking the appropriate steps. Like I said
+
+660
+00:34:26,632 --> 00:34:31,592
+before, for everyone their motherland
+
+661
+00:34:31,592 --> 00:34:37,842
+has to be their inspiring, final
+
+662
+00:34:37,842 --> 00:34:42,342
+destination that they will feel
+
+663
+00:34:42,342 --> 00:34:45,442
+comfortable in.
+
+664
+00:34:45,442 --> 00:34:48,892
+We do not need to live in foreign lands.
+
+665
+00:34:48,892 --> 00:34:52,332
+You always have to live on your own land.
+
+666
+00:34:52,332 --> 00:34:55,712
+The next generation... you will teach
+
+667
+00:34:55,712 --> 00:35:00,732
+the next generation about their own land.
+
+668
+00:35:00,732 --> 00:35:03,902
+The tree that I talked about earlier,
+
+669
+00:35:03,902 --> 00:35:06,002
+you are going to plant it on
+
+670
+00:35:06,002 --> 00:35:08,402
+your motherland. That is a beautiful
+
+671
+00:35:08,402 --> 00:35:10,192
+statement.
+
+672
+00:35:10,192 --> 00:35:15,942
+Can you tell me about yourself
+
+673
+00:35:15,942 --> 00:35:19,662
+in two words? About myself?
+
+674
+00:35:19,662 --> 00:35:22,192
+What are those two words?
+
+675
+00:35:22,192 --> 00:35:25,872
+I am proud that I am Armenian. I am still
+
+676
+00:35:25,872 --> 00:35:28,772
+having some difficulties and do not know
+
+677
+00:35:28,772 --> 00:35:31,282
+what the future will bring, but I am happy
+
+678
+00:35:31,282 --> 00:35:33,482
+that I live in Armenia. I always wanted to
+
+679
+00:35:33,482 --> 00:35:34,992
+live here.
+
+680
+00:35:34,992 --> 00:35:39,192
+I am thankful to the Armenian people
+
+681
+00:35:39,192 --> 00:35:42,222
+here that were always ready to help.
+
+682
+00:35:47,376 --> 00:35:51,322
+How can Syrian-Armenians help Armenia?
+
+683
+00:35:51,322 --> 00:35:56,422
+Every person that has a talent or can
+
+684
+00:35:56,422 --> 00:36:00,793
+bring something new to the table
+
+685
+00:36:00,793 --> 00:36:04,197
+or has a skill, depending on
+
+686
+00:36:04,197 --> 00:36:07,982
+the conditions, he/she can help
+
+687
+00:36:07,982 --> 00:36:11,532
+Armenia. Why not? It depends if
+
+688
+00:36:11,532 --> 00:36:14,022
+he/she has the right conditions.
+
+689
+00:36:14,022 --> 00:36:16,592
+He/she has to be given the opportunity.
+
+690
+00:36:16,592 --> 00:36:18,792
+The conditions have to be met
+
+691
+00:36:18,792 --> 00:36:20,112
+financially first.
+
+692
+00:36:20,112 --> 00:36:23,672
+You can work with things you know, so that
+
+693
+00:36:23,672 --> 00:36:27,522
+you can help others as well. If someone
+
+694
+00:36:27,522 --> 00:36:32,872
+has a personal store, he/she is not going
+
+695
+00:36:32,872 --> 00:36:36,012
+to work alone. That individual will have
+
+696
+00:36:36,012 --> 00:36:38,902
+other employees. Other families will be
+
+697
+00:36:38,902 --> 00:36:40,902
+able to benefit from them too. This is
+
+698
+00:36:40,902 --> 00:36:43,092
+the smallest way that they can help.
+
+699
+00:36:43,092 --> 00:36:45,472
+There are other ways too. They can
+
+700
+00:36:45,472 --> 00:36:48,502
+be artists or artisans for example.
+
+701
+00:36:48,502 --> 00:36:54,222
+Syrian-Armenians have some advanced
+
+702
+00:36:54,222 --> 00:36:57,602
+and knowledgeable workers now that work
+
+703
+00:36:57,602 --> 00:37:02,082
+in different centers like the national
+
+704
+00:37:02,082 --> 00:37:04,802
+library and other places that
+
+705
+00:37:04,802 --> 00:37:06,512
+I do not want to specify.
+
+706
+00:37:06,512 --> 00:37:09,442
+There are already Syrian-Armenians that
+
+707
+00:37:09,442 --> 00:37:12,872
+are working and are helping Armenia.
+
+708
+00:37:12,872 --> 00:37:20,252
+And... how did you make friends and make
+
+709
+00:37:20,252 --> 00:37:25,232
+a community here? New social life?
+
+710
+00:37:25,232 --> 00:37:27,292
+With Syrian-Armenians or Armenians from Armenia?
+
+711
+00:37:27,292 --> 00:37:30,172
+My surroundings are mostly
+
+712
+00:37:30,172 --> 00:37:33,032
+Eastern Armenians. I like change. I was
+
+713
+00:37:33,032 --> 00:37:35,492
+emotionally ready to accept all
+
+714
+00:37:35,492 --> 00:37:41,142
+the changes. Their life is interesting.
+
+715
+00:37:41,142 --> 00:37:43,892
+It was not difficult to get used to
+
+716
+00:37:43,892 --> 00:37:47,292
+the change. For me, it was nice.
+
+717
+00:37:47,292 --> 00:37:50,752
+I have many vast, rich,
+
+718
+00:37:50,752 --> 00:37:52,982
+and interesting surroundings.
+
+719
+00:37:52,982 --> 00:37:55,779
+What are? You were so happy when you
+
+720
+00:37:55,779 --> 00:37:58,172
+were saying Armenia has welcomed you
+
+721
+00:37:58,172 --> 00:38:00,028
+and maybe you have said it already, but
+
+722
+00:38:00,028 --> 00:38:01,772
+what are some examples of how
+
+723
+00:38:01,772 --> 00:38:02,712
+they welcomed you?
+
+724
+00:38:02,712 --> 00:38:04,202
+How Armenia has welcomed you?
+
+725
+00:38:04,202 --> 00:38:06,542
+How the Armenians were accepting
+
+726
+00:38:06,542 --> 00:38:09,142
+of us here? Example? Do you have
+
+727
+00:38:09,142 --> 00:38:10,842
+examples? How they welcomed us?
+
+728
+00:38:10,842 --> 00:38:13,582
+Like I said before... how the people?
+
+729
+00:38:13,582 --> 00:38:16,622
+Do you have stories or examples?
+
+730
+00:38:16,622 --> 00:38:18,732
+For example, it has happened that I have
+
+731
+00:38:18,732 --> 00:38:20,582
+been in some sort of transportation
+
+732
+00:38:20,582 --> 00:38:22,422
+and had to go somewhere
+
+733
+00:38:22,422 --> 00:38:23,992
+and they knew from the way
+
+734
+00:38:23,992 --> 00:38:26,262
+I talked that I spoke Western Armenian
+
+735
+00:38:26,262 --> 00:38:29,112
+and they have paid 100 AMD for me.
+
+736
+00:38:29,112 --> 00:38:33,822
+They wanted to do something. It has
+
+737
+00:38:33,822 --> 00:38:37,752
+happened that they did not take 100 AMD
+
+738
+00:38:37,752 --> 00:38:43,382
+from me or the taxi charged me less.
+
+739
+00:38:43,382 --> 00:38:46,652
+All these people are people I do not know.
+
+740
+00:38:46,652 --> 00:38:50,222
+Speaking about neighbours, as soon as
+
+741
+00:38:50,222 --> 00:38:52,942
+I would move...
+
+742
+00:38:52,942 --> 00:38:55,292
+they would ask me what I need.
+
+743
+00:38:55,292 --> 00:38:58,862
+With that question, you know that you are
+
+744
+00:38:58,862 --> 00:39:02,272
+not alone. There have always been people
+
+745
+00:39:02,272 --> 00:39:05,162
+who were willing to help us. It was not
+
+746
+00:39:05,162 --> 00:39:08,312
+only me. There have always been people
+
+747
+00:39:08,312 --> 00:39:11,402
+and institutions who wanted to help
+
+748
+00:39:11,402 --> 00:39:13,932
+(like the Red Cross, UN,
+
+749
+00:39:13,932 --> 00:39:17,332
+and Mission Armenia). They are
+
+750
+00:39:17,332 --> 00:39:21,202
+non-Syrian organizations. They already
+
+751
+00:39:21,202 --> 00:39:24,712
+help us. There are a lot of people here
+
+752
+00:39:24,712 --> 00:39:26,662
+that want to help us.
+
+753
+00:39:26,662 --> 00:39:29,052
+Is there anything you want to add that
+
+754
+00:39:29,052 --> 00:39:30,702
+you did not say?
+
+755
+00:39:30,702 --> 00:39:34,902
+There is a lot.
+
+756
+00:39:34,902 --> 00:39:37,712
+What kind of thing?
+
+757
+00:39:37,712 --> 00:39:39,992
+All the Armenians should come back to Armenia.
+
+758
+00:39:39,992 --> 00:39:43,812
+Please see, for example, my family has
+
+759
+00:39:43,812 --> 00:39:47,162
+always loved Armenia even before
+
+760
+00:39:47,162 --> 00:39:49,912
+seeing it. I already loved Armenia. When
+
+761
+00:39:49,912 --> 00:39:52,872
+we saw Armenia, we fell in love with it...
+
+762
+00:39:52,872 --> 00:39:55,262
+because you feel like you belong to it
+
+763
+00:39:55,262 --> 00:39:57,452
+and it belongs to you and is your mom.
+
+764
+00:39:57,452 --> 00:40:00,812
+With all its bad qualities, it is yours
+
+765
+00:40:00,812 --> 00:40:03,862
+and you belong to it. We really wanted
+
+766
+00:40:03,862 --> 00:40:07,002
+to come and move here. Since we always
+
+767
+00:40:07,002 --> 00:40:09,912
+thought about our work situation, we did
+
+768
+00:40:09,912 --> 00:40:12,412
+not take the necessary steps to move here.
+
+769
+00:40:12,412 --> 00:40:14,962
+You can see that the day came and that we
+
+770
+00:40:14,962 --> 00:40:17,332
+are here now. We should not have come in
+
+771
+00:40:17,332 --> 00:40:19,602
+this way. We should have been more
+
+772
+00:40:19,602 --> 00:40:22,962
+organized when we came here. In the end,
+
+773
+00:40:22,962 --> 00:40:25,272
+we heard that our place is our mother's
+
+774
+00:40:25,272 --> 00:40:30,842
+lap and not foreign lands. Syria,
+
+775
+00:40:30,842 --> 00:40:33,992
+my birthplace, is a very good place
+
+776
+00:40:33,992 --> 00:40:38,232
+in terms of its people and its government.
+
+777
+00:40:38,232 --> 00:40:40,772
+They are like family to us.
+
+778
+00:40:40,772 --> 00:40:44,582
+Your motherland should be your country.
+
+779
+00:40:44,582 --> 00:40:48,092
+All the Armenians, especially those that
+
+780
+00:40:48,092 --> 00:40:50,762
+had the convenience to work here, can
+
+781
+00:40:50,762 --> 00:40:55,302
+create jobs. They do not have to think.
+
+782
+00:40:55,302 --> 00:40:57,942
+There is not that much to think about.
+
+783
+00:40:57,942 --> 00:41:01,342
+They have to come and start from here
+
+784
+00:41:01,342 --> 00:41:04,422
+and after them the next generation.
+
+785
+00:41:04,422 --> 00:41:08,159
+When the Diasporans start to come
+
+786
+00:41:08,159 --> 00:41:11,719
+to Armenia, especially the youth, they
+
+787
+00:41:11,719 --> 00:41:15,482
+should not be easily discouraged and have
+
+788
+00:41:15,482 --> 00:41:20,052
+high hopes. You should create that hope.
+
+789
+00:41:20,052 --> 00:41:22,422
+From generation to generation, we get
+
+790
+00:41:22,422 --> 00:41:26,732
+better. We sit and watch the Diasporans
+
+791
+00:41:26,732 --> 00:41:29,592
+from afar. The love of Armenia is
+
+792
+00:41:29,592 --> 00:41:32,692
+not enough. We have to do something.
+
+793
+00:41:32,692 --> 00:41:36,865
+Everyone should do, whatever they can do.
+
+794
+00:41:36,865 --> 00:41:39,412
+There is a short story.
+
+795
+00:41:39,412 --> 00:41:44,092
+In the forest, a fire takes place.
+
+796
+00:41:44,092 --> 00:41:47,202
+All the animals... what does that word
+
+797
+00:41:47,202 --> 00:41:51,202
+mean? Fire! All the animals think about
+
+798
+00:41:51,202 --> 00:41:54,942
+saving their souls and run away. All
+
+799
+00:41:54,942 --> 00:42:01,252
+of a sudden, they see a bird on its back
+
+800
+00:42:01,252 --> 00:42:04,592
+and its feet up. They ask the bird, what
+
+801
+00:42:04,592 --> 00:42:07,412
+are you doing? Run away and save your
+
+802
+00:42:07,412 --> 00:42:10,152
+soul. You can get burnt and die. The bird
+
+803
+00:42:10,152 --> 00:42:13,885
+says, no, I am holding up the sky.
+
+804
+00:42:13,885 --> 00:42:17,615
+So, that bird with its small and weak feet
+
+805
+00:42:17,615 --> 00:42:20,255
+is trying to do its part.
+
+806
+00:42:20,255 --> 00:42:25,855
+It holds up the sky to protect and save
+
+807
+00:42:25,855 --> 00:42:28,565
+the forest. Sorry, it was not fire.
+
+808
+00:42:28,565 --> 00:42:30,295
+You could say that it was the end
+
+809
+00:42:30,295 --> 00:42:31,547
+of the world.
+
+810
+00:42:31,547 --> 00:42:34,745
+If everyone does what they
+
+811
+00:42:34,745 --> 00:42:37,975
+can like the bird in the story and does
+
+812
+00:42:37,975 --> 00:42:40,345
+not get discouraged, something will
+
+813
+00:42:40,345 --> 00:42:44,035
+happen. So, we can do something to help.
+
+814
+00:42:47,095 --> 00:42:49,285
+Anything else?
+
+815
+00:42:49,285 --> 00:42:52,525
+No, that is all. I am a teacher I can
+
+816
+00:42:52,525 --> 00:42:55,045
+talk all morning.
+
+817
+00:42:55,078 --> 00:42:57,000
+We learned a lot from you.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,8 +39,9 @@ def test_srt_conversion(mock_writer, mock_convert ):
     assert res["input_path"] == infolder 
     assert str(res["output_path"]) == str(MAIN_PATH)
     main(**res)
-    assert mock_writer.call_count == len(os.listdir(res["input_path"]))
-    assert mock_convert.call_count == len(os.listdir(res["input_path"]))
+    n_files = len([i for i in os.listdir(res["input_path"]) if not i.startswith(".")])
+    assert mock_writer.call_count == n_files
+    assert mock_convert.call_count == n_files
  
 @patch("textgrid_convert.ttextgrid_convert.convert_to_txtgrid", autospec=True)
 @patch("textgrid_convert.iotools.filewriter", autospec=True)
@@ -98,8 +99,9 @@ def test_darla_conversion(mock_writer, mock_convert ):
         assert res["input_path"] == str(path)
         assert str(res["output_path"]) == str(MAIN_PATH)
         main(**res)
-        assert mock_writer.call_count == len(os.listdir(res["input_path"]))
-        assert mock_convert.call_count == len(os.listdir(res["input_path"]))
+        n_files = len([i for i in os.listdir(res["input_path"]) if not i.startswith(".")])
+        assert mock_writer.call_count == n_files 
+        assert mock_convert.call_count ==  n_files
         mock_writer.call_count = 0
         mock_convert.call_count = 0
 

--- a/tests/test_srtparser.py
+++ b/tests/test_srtparser.py
@@ -1,11 +1,13 @@
 import pathlib
 from textgrid_convert.srtParser import srtParser
-import textgrid_convert.textgridtools as tgt
+from textgrid_convert.textgridtools import merge_text_with_newlines
 from globals import INFILES_SRT, OUTFILES
 
 DOWNSUB = INFILES_SRT / "downsub.srt"
 SRT_TO_GRID = OUTFILES / "srt_to_grid.TextGrid"
 SRT_TO_DARLA = OUTFILES / "srt_to_darla.TextGrid"
+NEWLINES = INFILES_SRT / "issue_43.srt"
+FULLTEXT_NEWLINES = INFILES_SRT / "issue_43_fulltext.srt"
 
 
 def test_class_init():
@@ -27,7 +29,6 @@ def test_timeconvert():
     parser = srtParser(intext)
     converted = parser.parse_timestamp(intext)
     assert converted == 1579.00
-    print(converted)
     intext = "00:01:01,579"
     parser = srtParser(intext)
     converted = parser.parse_timestamp(intext)
@@ -67,3 +68,15 @@ def test_to_darla():
     txtgrid = parser.to_darla_textgrid()
     with open(str(SRT_TO_DARLA), "w", encoding="utf-8") as srtout:
         srtout.write(txtgrid)
+
+def test_file_with_newlines():
+    """
+   """
+    with open(str(NEWLINES), "r", encoding="utf-8") as srtin:
+        txt = srtin.read()
+    parser = srtParser(txt, preprocessors=[merge_text_with_newlines])
+    txtgrid = parser.to_darla_textgrid()
+    with open(str(FULLTEXT_NEWLINES), "r", encoding="utf-8") as srtin:
+        txt = srtin.read()
+    parser = srtParser(txt, preprocessors=[merge_text_with_newlines])
+    txtgrid = parser.to_darla_textgrid()

--- a/textgrid_convert/srtParser.py
+++ b/textgrid_convert/srtParser.py
@@ -12,21 +12,23 @@ class srtParser(ParserABC):
     Read and parse an srt formatted file
     Inofficial specs here: http://forum.doom9.org/showthread.php?p=470941#post470941
 
-    Attributes:
-        file_name(optional)
-        srt_text(str)
     """
 
-    def __init__(self, transcription, unique_id=None):
+    def __init__(self, transcription, preprocessors=[], unique_id=None):
         """
         Initializer
 
         Args:
             str_text(str)
         """
-        self.transcription = transcription
+        self.preprocessors = preprocessors
+        if self.preprocessors:
+            for prep in self.preprocessors:
+                self.transcription = prep(transcription)
+        else:
+            self.transcription = transcription
         self.transcription_dict = {}
-        self.parse_transcription(transcription)
+        self.parse_transcription(self.transcription)
         if unique_id is not None:
             self.unique_id=unique_id
 
@@ -59,7 +61,7 @@ class srtParser(ParserABC):
         """
         if not srt_text:
             srt_text = self.transcription
-        for chunk_id, timestamps, text in self.srt_generator(srt_text.splitlines(), separator=""):
+        for chunk_id, timestamps, text in self.srt_generator(srt_text.splitlines()):
             start, end = timestamps.split(time_stamp_sep)
             self.transcription_dict[chunk_id] = {
                     "speaker_name": speaker_name,
@@ -68,11 +70,10 @@ class srtParser(ParserABC):
                     "text": text}
         return copy.deepcopy(self.transcription_dict)
 
-    def srt_generator(self, filein, separator="\n"):
+    def srt_generator(self, filein):
         """
         Args:
             filein(file read object or other iterable)
-            separator(str): separator between records
         Returns:
             generator over chunk_id, timestamp, text
         """
@@ -112,6 +113,6 @@ class srtParser(ParserABC):
         log.debug("Setting tier name to '%s'" %alias)
         for key, values in darla_dict.items():
             output_dict[key] = values
-            output_dict[key]["speaker_name"]  = alias
+            output_dict[key]["speaker_name"] = alias
         textgrid = self.to_textgrid(output_dict)
         return textgrid

--- a/textgrid_convert/srtParser.py
+++ b/textgrid_convert/srtParser.py
@@ -6,6 +6,7 @@ import copy
 from textgrid_convert.ParserABC import ParserABC
 
 log = logging.getLogger(__name__)
+from textgrid_convert.textgridtools import merge_text_with_newlines
 
 class srtParser(ParserABC):
     """
@@ -14,7 +15,7 @@ class srtParser(ParserABC):
 
     """
 
-    def __init__(self, transcription, preprocessors=[], unique_id=None):
+    def __init__(self, transcription, preprocessors=[merge_text_with_newlines], unique_id=None):
         """
         Initializer
 

--- a/textgrid_convert/textgridtools.py
+++ b/textgrid_convert/textgridtools.py
@@ -143,8 +143,6 @@ def merge_text_with_newlines(input_string):
     separator = "\n"
     text_line_pattern = re.compile(r".*[A-Za-z].*")
     split_string = input_string.split(separator)
-    print("--")
-    print(split_string)
     output_split_string = []
     aggregated_strings = []
     # since the first line will always be an index, this will not wrap around
@@ -158,5 +156,4 @@ def merge_text_with_newlines(input_string):
             aggregated_strings.append(line)
     if aggregated_strings:
         output_split_string.append(" ".join(aggregated_strings))
-    print(output_split_string)
     return separator.join(output_split_string)

--- a/textgrid_convert/textgridtools.py
+++ b/textgrid_convert/textgridtools.py
@@ -1,6 +1,7 @@
 """
 Collect TextGrid related functionality here
 """
+import re
 import logging
 log = logging.getLogger(__name__)
 
@@ -130,3 +131,32 @@ def to_long_textgrid(tier_dict, tier_key="speaker_name", tier_class="IntervalTie
             tier_intervals.append(interval_str)
         tiers = tiers + [tier_intro + "\n".join(tier_intervals)]
     return "\n".join([file_str, "\n".join(tiers)]) 
+
+def merge_text_with_newlines(input_string):
+    """
+    Remove all empty lines from `input_string` as these can break the parser
+    Args:
+        input_string (str):
+    Returns:
+        input_string with empty lines dropped
+    """
+    separator = "\n"
+    text_line_pattern = re.compile(r".*[A-Za-z].*")
+    split_string = input_string.split(separator)
+    print("--")
+    print(split_string)
+    output_split_string = []
+    aggregated_strings = []
+    # since the first line will always be an index, this will not wrap around
+    for ind, line in enumerate(split_string):
+        if not text_line_pattern.match(line):
+            if aggregated_strings:
+                output_split_string.append(" ".join(aggregated_strings))
+                aggregated_strings = []
+            output_split_string.append(line)
+        else:
+            aggregated_strings.append(line)
+    if aggregated_strings:
+        output_split_string.append(" ".join(aggregated_strings))
+    print(output_split_string)
+    return separator.join(output_split_string)


### PR DESCRIPTION
## Summary

Fixes #43 

## Details

- Add [preprocessor](https://github.com/patrickschu/textgrid-convert/blob/2f18fbd734aa80f93afc0815ad07cd0185f2157c/textgrid_convert/srtParser.py#L17) attribute to srtParser and default to newline merge function
- Add function `merge_text_with_newlines` to [tools](https://github.com/patrickschu/textgrid-convert/blob/2f18fbd734aa80f93afc0815ad07cd0185f2157c/textgrid_convert/textgridtools.py#L135) 
- Change setting in ttextgridconvert for CLI use
- Add tests
